### PR TITLE
Update cider-nrepl to fix syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Wait a bit, then browse to [http://localhost:3449](http://localhost:3449).
 
 ## Production Build
 
-
 To compile clojurescript to javascript:
 
 ```
@@ -37,13 +36,14 @@ lein clean
 lein cljsbuild once min
 ```
 
-
 ### SASS Compilation
+
 Using [lein-sassy](https://github.com/vladh/lein-sassy)
 
 Compile files once
+
 ```
-use lein sass once
+lein sass once
 ```
 
 Watch files for changes

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                    [com.cemerick/piggieback "0.2.1"]]
 
     :plugins      [[lein-figwheel "0.5.7"]
-                   [cider/cider-nrepl "0.15.0-SNAPSHOT"]
+                   [cider/cider-nrepl "0.15.1"]
                    [lein-sassy "1.0.8"]]
     :sass {:src "resources/app/scss"
            :dst "resources/public/css/"}


### PR DESCRIPTION
Fixes this error when running `lein clean`:

```
clojure.lang.Compiler$CompilerException: Syntax error reading source at (cider/nrepl/middleware/test.clj:129:57).
#:clojure.error{:phase :read-source, :line 129, :column 57, :source "cider/nrepl/middleware/test.clj"}
 at clojure.lang.Compiler.load (Compiler.java:7642)
```